### PR TITLE
basic homepage structure with light and dark theme

### DIFF
--- a/app/components/ThemeSwitcher.js
+++ b/app/components/ThemeSwitcher.js
@@ -1,0 +1,54 @@
+import { useState, useEffect } from "react";
+import { GoSun, GoMoon } from "react-icons/go";
+
+export default function ThemeSwitcher() {
+  const [mounted, setMounted] = useState(false);
+  const [theme, setTheme] = useState("light");
+
+  useEffect(() => {
+    setMounted(true);
+
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme) {
+      setTheme(savedTheme);
+      document.documentElement.classList.add(savedTheme);
+    } else {
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      setTheme(prefersDark ? "dark" : "light");
+      document.documentElement.classList.add(prefersDark ? "dark" : "light");
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    if (theme === "dark") {
+      document.documentElement.classList.remove("dark");
+      document.documentElement.classList.add("light");
+      localStorage.setItem("theme", "light");
+      setTheme("light");
+    } else {
+      document.documentElement.classList.remove("light");
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+      setTheme("dark");
+    }
+  };
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 mt-4 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-dark-secondary dark:focus:ring-light-secondary"
+    >
+      {theme === "dark" ? (
+        <GoSun className="w-6 h-6 text-light-secondary dark:text-dark-secondary" />
+      ) : (
+        <GoMoon className="w-6 h-6 text-dark-accent dark:text-dark-accent" />
+      )}
+    </button>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,26 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  @apply bg-light-neutral text-light-primary;
 }
 
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
+.dark body {
+  @apply bg-dark-neutral text-dark-primary;
 }

--- a/app/page.js
+++ b/app/page.js
@@ -1,101 +1,18 @@
-import Image from "next/image";
+"use client";
+
+import ThemeSwitcher from "./components/ThemeSwitcher";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="https://nextjs.org/icons/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
-              app/page.js
-            </code>
-            .
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="https://nextjs.org/icons/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:min-w-44"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <section className="p-6 min-h-screen">
+      <div className="text-right">
+        <ThemeSwitcher />
+      </div>
+      <div className="flex flex-col items-center justify-center">
+        <h1 className="text-3xl font-bold mb-4">Welcome to ShrinkUrlNow</h1>
+        <p className="text-lg">A simple tool to shorten your URLs</p>
+        <div className="pt-12">**Add form here**</div>
+      </div>
+    </section>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.2.15",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-icons": "^5.3.0"
       },
       "devDependencies": {
         "eslint": "^8",
@@ -4074,6 +4075,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.2.15"
+    "react-icons": "^5.3.0"
   },
   "devDependencies": {
-    "postcss": "^8",
-    "tailwindcss": "^3.4.1",
     "eslint": "^8",
-    "eslint-config-next": "14.2.15"
+    "eslint-config-next": "14.2.15",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,10 +6,21 @@ module.exports = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    darkMode: "class",
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        light: {
+          primary: "#B17457",
+          secondary: "#D8D2C2",
+          accent: "#4A4947",
+          neutral: "#FAF7F0",
+        },
+        dark: {
+          primary: "#6A9AB0",
+          secondary: "#3A6D8C",
+          accent: "#EAD8B1",
+          neutral: "#001F3F",
+        },
       },
     },
   },


### PR DESCRIPTION
This PR adds a basic homepage structure
- I included the toggle-button for testing the themes, but it should probably be moved to the header (when its being created)

| light    | dark |
| -------- | ------- |
| <img width="1440" alt="Screenshot 2024-10-20 at 11 34 03" src="https://github.com/user-attachments/assets/d795202f-cdb0-4e62-bcb9-fb38598c242d"> | <img width="1440" alt="Screenshot 2024-10-20 at 11 39 52" src="https://github.com/user-attachments/assets/b0f2cff9-7c94-4b10-85be-b68f532ccf49">  |


**Focused toggle button**
| light  | dark |
| -------- | ------- |
| <img width="1440" alt="Screenshot 2024-10-20 at 11 38 04" src="https://github.com/user-attachments/assets/d3fe3b43-17b7-4e38-a60d-72f8f7b5fdde"> | <img width="1440" alt="Screenshot 2024-10-20 at 11 33 46" src="https://github.com/user-attachments/assets/2ffbee3f-5225-4bc6-bb61-94d261b09588"> |
